### PR TITLE
Assign username and password to MQTT-SN's CONNECT message.

### DIFF
--- a/etc/emq_sn.conf
+++ b/etc/emq_sn.conf
@@ -5,3 +5,5 @@
 mqtt.sn.port = 1884
 mqtt.sn.advertise_duration = 900
 mqtt.sn.gateway_id = 1
+mqtt.sn.username = mqtt_sn_user
+mqtt.sn.password = abc

--- a/priv/emq_sn.schema
+++ b/priv/emq_sn.schema
@@ -15,6 +15,28 @@
   {datatype, integer}
 ]}.
 
+{mapping, "mqtt.sn.username", "emq_sn.username", [
+  {datatype, string}
+]}.
+
+{mapping, "mqtt.sn.password", "emq_sn.password", [
+  {datatype, string}
+]}.
+
+
 {translation, "emq_sn.listener", fun(Conf) ->
-  Port = cuttlefish:conf_get("mqtt.sn.port", Conf), {Port, []}
+  Port = cuttlefish:conf_get("mqtt.sn.port", Conf),
+  {Port, []}
 end}.
+
+
+{translation, "emq_sn.username", fun(Conf) ->
+  Username = cuttlefish:conf_get("mqtt.sn.username", Conf),
+  list_to_binary(Username)
+end}.
+
+{translation, "emq_sn.password", fun(Conf) ->
+  Password = cuttlefish:conf_get("mqtt.sn.password", Conf),
+  list_to_binary(Password)
+end}.
+


### PR DESCRIPTION
Without username(https://github.com/emqtt/emqttd/issues/1041), any auth plugin may reject mqtt-sn's connection request.