### PR TITLE
Seperate emq_sn from emqttd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ BUILD_DEPS = emqttd cuttlefish
 dep_emqttd = git https://github.com/emqtt/emqttd emq22
 dep_cuttlefish = git https://github.com/emqtt/cuttlefish
 
-TEST_DEPS = emqttc
-dep_emqttc   = git https://github.com/emqtt/emqttc
-
 ERLC_OPTS += +'{parse_transform, lager_transform}'
 TEST_ERLC_OPTS += +'{parse_transform, lager_transform}'
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ mqtt.sn.password = abc
 ```
 
 - mqtt.sn.port
-  * The UDP port which emqx-sn is listening on.
+  * The UDP port which emq-sn is listening on.
 - mqtt.sn.advertise_duration
-  * The duration(seconds) that emqx-sn broadcast ADVERTISE message through.
+  * The duration(seconds) that emq-sn broadcast ADVERTISE message through.
 - mqtt.sn.gateway_id
   * Gateway id in ADVERTISE message.
 - mqtt.sn.username
-  * This parameter is optional. If specified, emqx-sn will connect EMQX core with this username. It is useful if any auth plug-in is enabled.
+  * This parameter is optional. If specified, emq-sn will connect EMQTTD core with this username. It is useful if any auth plug-in is enabled.
 - mqtt.sn.password
   * This parameter is optional. Pair with username above.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,24 @@ Configure Plugin
 
 File: etc/emq_sn.conf
 
-```erlang
-mqtt.sn.port = 1884
 ```
+mqtt.sn.port = 1884
+mqtt.sn.advertise_duration = 900
+mqtt.sn.gateway_id = 1
+mqtt.sn.username = mqtt_sn_user
+mqtt.sn.password = abc
+```
+
+- mqtt.sn.port
+  * The UDP port which emqx-sn is listening on.
+- mqtt.sn.advertise_duration
+  * The duration(seconds) that emqx-sn broadcast ADVERTISE message through.
+- mqtt.sn.gateway_id
+  * Gateway id in ADVERTISE message.
+- mqtt.sn.username
+  * This parameter is optional. If specified, emqx-sn will connect EMQX core with this username. It is useful if any auth plug-in is enabled.
+- mqtt.sn.password
+  * This parameter is optional. Pair with username above.
 
 ## Usage
 

--- a/include/emq_sn.hrl
+++ b/include/emq_sn.hrl
@@ -167,10 +167,10 @@
         #mqtt_sn_message{type     = ?SN_WILLMSGRESP,
                          variable = ReturnCode}).
 
--define(SN_NORMAL_TOPIC,    0).
+-define(SN_NORMAL_TOPIC,     0).
 -define(SN_PREDEFINED_TOPIC, 1).
--define(SN_SHORT_TOPIC, 2).
--define(SN_RESERVED_TOPIC, 2).
+-define(SN_SHORT_TOPIC,      2).
+-define(SN_RESERVED_TOPIC,   3).
 
 
 -define(SN_INVALID_TOPIC_ID, 0).

--- a/test/emq_sn_message_SUITE.erl
+++ b/test/emq_sn_message_SUITE.erl
@@ -33,11 +33,11 @@ all() -> [advertise_test, searchgw_test, gwinfo_test, connect_test, connack_test
 
 
 init_per_suite(Config) ->
-    application:start(lager),
+    lager_common_test_backend:bounce(debug),
     Config.
 
 end_per_suite(_Config) ->
-    application:stop(lager).
+    ok.
 
 
 

--- a/test/emq_sn_protocol_SUITE.erl
+++ b/test/emq_sn_protocol_SUITE.erl
@@ -39,7 +39,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    application:stop(emqx_sn).
+    application:stop(emq_sn).
 
 
 

--- a/test/emq_sn_registry_SUITE.erl
+++ b/test/emq_sn_registry_SUITE.erl
@@ -29,11 +29,11 @@ all() -> [register_topic_test, register_topic_test2, register_topic_test3, regis
 
 
 init_per_suite(Config) ->
-    application:start(lager),
+    lager_common_test_backend:bounce(debug),
     Config.
 
 end_per_suite(_Config) ->
-    application:stop(lager).
+    ok.
 
 
 
@@ -72,10 +72,10 @@ register_topic_test2(_Config) ->
 
 
 register_topic_test3(_Config) ->
-    io:format("register_topic_test3 will take long long time ...~n"),
+    lager:debug("register_topic_test3 will take long long time ...~n"),
     start_link(),
     register_a_lot(1, 16#fffe),
-    io:format("start overflow~n"),
+    lager:debug("start overflow test~n"),
     ?assertEqual(undefined, register_topic(<<"ClientId">>, <<"TopicABC">>)),
     timer:sleep(500),
     ?assertEqual(1, lookup_topic_id(<<"ClientId">>, <<"Topic1">>)),
@@ -111,7 +111,7 @@ register_a_lot(Max, Max) ->
     ok;
 register_a_lot(N, Max) ->
     case (N rem 1024) of
-        0 -> io:format("register_a_lot N=~p~n", [N]);
+        0 -> lager:debug("register_a_lot N=~p/65536, long long time, please be patient~n", [N]);
         _ -> ok
     end,
     TopicString = io_lib:format("Topic~p", [N]),

--- a/test/test_mqtt_broker.erl
+++ b/test/test_mqtt_broker.erl
@@ -1,0 +1,248 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2016-2017 Feng Lee <feng@emqtt.io>.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(test_mqtt_broker).
+
+-compile(export_all).
+
+-behaviour(gen_server).
+
+-record(state, {subscriber, peer, pkt_opts, connect_pkt, last_puback, last_pubrel, rx_message, subed, unsubed}).
+
+-include_lib("emqttd/include/emqttd.hrl").
+-include_lib("emqttd/include/emqttd_protocol.hrl").
+
+
+-define(LOG(Format, Args),
+    lager:debug("TEST broker: " ++ Format, Args)).
+
+proto_init(Peer, SendFun, PktOpts) ->
+    KeepaliveDuration = 3,   % seconds
+    self() ! {keepalive, start, KeepaliveDuration},
+    put(debug_unit_test_send_func, SendFun),
+    gen_server:call(?MODULE, {init, self(), Peer, PktOpts}).
+
+proto_receive(Packet, _Proto) ->
+    case gen_server:call(?MODULE, {received_packet, Packet}) of
+        {ok, State, OutPkt} ->
+            case OutPkt of
+                undefined -> ok;
+                _ ->
+                    Send = get(debug_unit_test_send_func),
+                    Send(OutPkt)
+            end,
+            {ok, State};
+        Other -> Other
+    end.
+
+get_online_user() ->
+    gen_server:call(?MODULE, get_online_user).
+
+get_puback() ->
+    gen_server:call(?MODULE, get_puback).
+
+get_pubrel() ->
+    gen_server:call(?MODULE, get_pubrel).
+
+get_published_msg() ->
+    gen_server:call(?MODULE, get_published_msg).
+
+get_subscrbied_topic() ->
+    gen_server:call(?MODULE, get_subscribed_topic).
+
+get_unsubscrbied_topic() ->
+    gen_server:call(?MODULE, get_unsubscribed_topic).
+
+dispatch(MsgId, Qos, Retain, Topic, Msg) ->
+    gen_server:call(?MODULE, {dispatch, {MsgId, Qos, Retain, Topic, Msg}}).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:stop(?MODULE).
+
+init(_Param) ->
+    {ok, #state{subscriber = undefined}}.
+
+
+handle_call({init, Subscriber, Peer, PktOpts}, _From, State) ->
+    ?LOG("test broker init Subscriber=~p, Peer=~p, SendFun=~p, PktOpts=~p, broker_pid=~p~n", [Subscriber, Peer, PktOpts, self()]),
+    {reply, ok, State#state{subscriber = Subscriber, peer = Peer, pkt_opts = PktOpts}};
+
+handle_call({received_packet, ?CONNECT_PACKET(ConnPkt)}, _From, State=#state{}) ->
+    #mqtt_packet_connect{client_id  = ClientId, username = Username} = ConnPkt,
+    ?LOG("test broker get CONNECT ~p~n", [ConnPkt]),
+    (is_binary(ClientId) and is_binary(Username)) orelse error("ClientId and Username should be binary"),
+    OutPkt = ?CONNACK_PACKET(?CONNACK_ACCEPT),
+    {reply, {ok, [], OutPkt}, State#state{connect_pkt = ConnPkt}};
+
+handle_call({received_packet, Msg = ?PUBLISH_PACKET(Qos, PacketId)}, _From, State=#state{}) ->
+    ?LOG("test broker get PUBLISH ~p~n", [Msg]),
+    #mqtt_packet{header = Header, variable = Var, payload = Payload} = Msg,
+    #mqtt_packet_header{type = ?PUBLISH, dup = _Dup, qos = Qos, retain = Retain} = Header,
+    #mqtt_packet_publish{topic_name = TopicName, packet_id = MsgId} = Var,
+    OutPkt = case Qos of
+                ?QOS1 -> ?PUBACK_PACKET(?PUBACK, MsgId);
+                ?QOS2 -> ?PUBACK_PACKET(?PUBREC, MsgId);
+                _ -> undefined
+            end,
+    {reply, {ok, [], OutPkt}, State#state{rx_message = {MsgId, Qos, Retain, TopicName, Payload}}};
+
+handle_call({received_packet, ?PUBACK_PACKET(?PUBACK, MsgId)}, _From, State=#state{}) ->
+    ?LOG("test broker get PUBACK MsgId=~p~n", [MsgId]),
+    {reply, {ok, []}, State#state{last_puback = MsgId}};
+
+handle_call({received_packet, ?PUBACK_PACKET(?PUBREL, MsgId)}, _From, State=#state{}) ->
+    ?LOG("test broker get PUBREL MsgId=~p~n", [MsgId]),
+    OutPkt = ?PUBACK_PACKET(?PUBCOMP, MsgId),
+    {reply, {ok, [], OutPkt}, State#state{last_pubrel = MsgId}};
+
+handle_call({received_packet, ?SUBSCRIBE_PACKET(MsgId, [{TopicName, Qos}])}, _From, State=#state{subscriber = Pid}) ->
+    ?LOG("test broker get SUBSCRIBE MsgId=~p, TopicName=~p, Qos=~p~n", [MsgId, TopicName, Qos]),
+    Pid ! {suback, MsgId, [Qos]},
+    {reply, {ok, []}, State#state{subed = {TopicName, Qos}}};
+
+handle_call({received_packet, ?UNSUBSCRIBE_PACKET(MsgId, [TopicName])}, _From, State=#state{}) ->
+    ?LOG("test broker get UNSUBSCRIBE MsgId=~p, TopicName=~p~n", [MsgId, TopicName]),
+    OutPkt = ?UNSUBACK_PACKET(MsgId),
+    {reply, {ok, [], OutPkt}, State#state{unsubed = TopicName}};
+
+handle_call({received_packet, ?PACKET(?DISCONNECT)}, _From, State=#state{}) ->
+    ?LOG("test broker get DISCONNECT~n", []),
+    {reply, {stop, normal, []}, State#state{connect_pkt = undefined}};
+
+
+
+handle_call(get_online_user, _From, State=#state{connect_pkt = undefined}) ->
+    ?LOG("test broker get online user none~n", []),
+    {reply, {undefined, undefined}, State};
+
+handle_call(get_online_user, _From, State=#state{connect_pkt = ConnPkt}) ->
+    #mqtt_packet_connect{client_id  = ClientId, username = Username} = ConnPkt,
+    ?LOG("test broker get online ClientId=~p, Username=~p~n", [ClientId, Username]),
+    {reply, {ClientId, Username}, State};
+
+handle_call(get_puback, _From, State=#state{last_puback = MsgId}) ->
+    ?LOG("test broker get published PUBACK MsgId=~p~n", [MsgId]),
+    {reply, MsgId, State};
+
+handle_call(get_pubrel, _From, State=#state{last_pubrel = MsgId}) ->
+    ?LOG("test broker get published PUBREL MsgId=~p~n", [MsgId]),
+    {reply, MsgId, State};
+
+handle_call(get_published_msg, _From, State=#state{rx_message = undefined}) ->
+    ?LOG("test broker get published none~n", []),
+    {reply, {undefined, undefined, undefined, undefined, undefined}, State};
+
+handle_call(get_published_msg, _From, State=#state{rx_message = {MsgId, Qos, Retain, TopicName, Payload}}) ->
+    ?LOG("test broker get published MsgId=~p, Qos=~p, Retain=~p, TopicName=~p, Payload=~p~n", [MsgId, Qos, Retain, TopicName, Payload]),
+    {reply, {MsgId, Qos, Retain, TopicName, Payload}, State};
+
+handle_call(get_subscribed_topic, _From, State=#state{subed = undefined}) ->
+    ?LOG("test broker get subscribed topic=undefined~n", []),
+    {reply, undefined, State};
+
+handle_call(get_subscribed_topic, _From, State=#state{subed = {TopicName, Qos}}) ->
+    ?LOG("test broker get subscribed topic=~p, Qos=~p~n", [TopicName, Qos]),
+    {reply, TopicName, State};
+
+handle_call(get_unsubscribed_topic, _From, State=#state{unsubed = TopicName}) ->
+    ?LOG("test broker get unsubscribed topic=~p~n", [TopicName]),
+    {reply, TopicName, State};
+
+handle_call({dispatch, {_MsgId, _Qos, _Retain, Topic, Msg}}, _From, State=#state{subscriber = undefined}) ->
+    ?LOG("test broker CAN NOT dispatch topic=~p, Msg=~p due to no subscriber~n", [Topic, Msg]),
+    {reply, ok, State};
+
+handle_call({dispatch, {MsgId, Qos, Retain, Topic, Msg}}, _From, State=#state{subscriber = SubProc}) ->
+    ?LOG("test broker dispatch topic=~p, Msg=~p~n", [Topic, Msg]),
+    (is_binary(Topic) and is_binary(Msg)) orelse error("Topic and Msg should be binary"),
+    SubProc ! {deliver, #mqtt_message{pktid = MsgId, qos = Qos, retain = Retain, topic = Topic, payload = Msg}},
+    {reply, ok, State};
+
+handle_call(stop, _From, State) ->
+    {stop, normal, stopped, State};
+
+handle_call(Req, _From, State) ->
+    ?LOG("test_mqtt_broker: ignore call Req=~p~n", [Req]),
+    {reply, {error, badreq}, State}.
+
+
+handle_cast(Msg, State) ->
+    ?LOG("test_mqtt_broker: ignore cast msg=~p~n", [Msg]),
+    {noreply, State}.
+
+handle_info(Info, State) ->
+    ?LOG("test_mqtt_broker: ignore info=~p~n", [Info]),
+    {noreply, State}.
+
+terminate(Reason, _State) ->
+    ?LOG("test_mqtt_broker: terminate Reason=~p~n", [Reason]),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+
+
+
+
+-record(keepalive, {statfun, statval, tsec, tmsg, tref, repeat = 0}).
+
+-type(keepalive() :: #keepalive{}).
+
+%% @doc Start a keepalive
+-spec(start(fun(), integer(), any()) -> undefined | keepalive()).
+start(_, 0, _) ->
+    undefined;
+start(StatFun, TimeoutSec, TimeoutMsg) ->
+    {ok, StatVal} = StatFun(),
+    #keepalive{statfun = StatFun, statval = StatVal,
+        tsec = TimeoutSec, tmsg = TimeoutMsg,
+        tref = timer(TimeoutSec, TimeoutMsg)}.
+
+%% @doc Check keepalive, called when timeout.
+-spec(check(keepalive()) -> {ok, keepalive()} | {error, any()}).
+check(KeepAlive = #keepalive{statfun = StatFun, statval = LastVal, repeat = Repeat}) ->
+    case StatFun() of
+        {ok, NewVal} ->
+            if NewVal =/= LastVal ->
+                {ok, resume(KeepAlive#keepalive{statval = NewVal, repeat = 0})};
+                Repeat < 1 ->
+                    {ok, resume(KeepAlive#keepalive{statval = NewVal, repeat = Repeat + 1})};
+                true ->
+                    {error, timeout}
+            end;
+        {error, Error} ->
+            {error, Error}
+    end.
+
+resume(KeepAlive = #keepalive{tsec = TimeoutSec, tmsg = TimeoutMsg}) ->
+    KeepAlive#keepalive{tref = timer(TimeoutSec, TimeoutMsg)}.
+
+%% @doc Cancel Keepalive
+-spec(cancel(keepalive()) -> ok).
+cancel(#keepalive{tref = TRef}) ->
+    cancel(TRef);
+cancel(undefined) ->
+    ok;
+cancel(TRef) ->
+        catch erlang:cancel_timer(TRef).
+
+timer(Sec, Msg) ->
+    erlang:send_after(timer:seconds(Sec), self(), Msg).


### PR DESCRIPTION
Make unit test simple and independent. No matter what emqttd has changed (except the API offered for emq_sn), the emq_sn will not be effected.