### PR TITLE
Handle normal topic id as predefined topic id , to be compatible with paho mqtt-sn library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BUILD_DEPS = emqttd cuttlefish
 dep_emqttd = git https://github.com/emqtt/emqttd emq22
 dep_cuttlefish = git https://github.com/emqtt/cuttlefish
 
+ERLC_OPTS += +debug_info
 ERLC_OPTS += +'{parse_transform, lager_transform}'
 TEST_ERLC_OPTS += +'{parse_transform, lager_transform}'
 

--- a/src/emq_sn_gateway.erl
+++ b/src/emq_sn_gateway.erl
@@ -496,7 +496,9 @@ do_unsubscribe(_, _TopicId, MsgId, StateData) ->
     send_message(?SN_UNSUBACK_MSG(MsgId), StateData),
     next_state(connected, StateData).
 
-
+do_publish(?SN_NORMAL_TOPIC, TopicId, Data, Flags, MsgId, StateData) ->
+    %% Handle normal topic id as predefined topic id, to be compatible with paho mqtt-sn library
+    do_publish(?SN_PREDEFINED_TOPIC, TopicId, Data, Flags, MsgId, StateData);
 do_publish(?SN_PREDEFINED_TOPIC, TopicId, Data, Flags, MsgId, StateData=#state{client_id = ClientId}) ->
     #mqtt_sn_flags{qos = Qos, dup = Dup, retain = Retain} = Flags,
     case emq_sn_registry:lookup_topic(ClientId, TopicId) of


### PR DESCRIPTION
Fix for #12.