### PR TITLE
Add function of processing received publish message with qos=-1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ mqtt.sn.port = 1884
 mqtt.sn.advertise_duration = 900
 mqtt.sn.gateway_id = 1
 mqtt.sn.enable_stats = off
+mqtt.sn.enable_qos3 = off
 mqtt.sn.predefined.topic.0 = reserved
 mqtt.sn.predefined.topic.1 = /predefined/topic/name/hello
 mqtt.sn.predefined.topic.2 = /predefined/topic/name/nice
@@ -28,6 +29,8 @@ mqtt.sn.password = abc
   * Gateway id in ADVERTISE message.
 - mqtt.sn.enable_stats
   * To control whether write statistics data into ETS table for dashbord to read.
+- mqtt.sn.enable_qos3
+  * To control whether accept and process the received publish message with qos=-1.
 - mqtt.sn.predefined.topic.N
   * The pre-defined topic name corresponding to the pre-defined topic id of N. Note that the pre-defined topic id of 0 is reserved.
 - mqtt.sn.username

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ File: etc/emq_sn.conf
 mqtt.sn.port = 1884
 mqtt.sn.advertise_duration = 900
 mqtt.sn.gateway_id = 1
+mqtt.sn.enable_stats = off
+mqtt.sn.predefined.topic.0 = reserved
+mqtt.sn.predefined.topic.1 = /predefined/topic/name/hello
+mqtt.sn.predefined.topic.2 = /predefined/topic/name/nice
 mqtt.sn.username = mqtt_sn_user
 mqtt.sn.password = abc
 ```
@@ -22,6 +26,10 @@ mqtt.sn.password = abc
   * The duration(seconds) that emq-sn broadcast ADVERTISE message through.
 - mqtt.sn.gateway_id
   * Gateway id in ADVERTISE message.
+- mqtt.sn.enable_stats
+  * To control whether write statistics data into ETS table for dashbord to read.
+- mqtt.sn.predefined.topic.N
+  * The pre-defined topic name corresponding to the pre-defined topic id of N. Note that the pre-defined topic id of 0 is reserved.
 - mqtt.sn.username
   * This parameter is optional. If specified, emq-sn will connect EMQ core with this username. It is useful if any auth plug-in is enabled.
 - mqtt.sn.password
@@ -55,6 +63,12 @@ sleeping device
 -----------
 
 PINGREQ must have a ClientId which is identical to the one in CONNECT message. Without ClientId, emq-sn will ignore such PINGREQ.
+
+
+pre-defined topics
+-----------
+
+The mapping of a pre-defined topic id and topic name should be known inadvance by both client's application and gateway. We define this mapping info in emq_sn.conf file, and which shall be kept equivalent in all client's side.
 
 
 

--- a/etc/emq_sn.conf
+++ b/etc/emq_sn.conf
@@ -6,6 +6,7 @@ mqtt.sn.port = 1884
 mqtt.sn.advertise_duration = 900
 mqtt.sn.gateway_id = 1
 mqtt.sn.enable_stats = off
+mqtt.sn.enable_qos3 = off
 
 ## topicid 0x0000 and 0xFFFF is reserved
 mqtt.sn.predefined.topic.0 = reserved

--- a/include/emq_sn.hrl
+++ b/include/emq_sn.hrl
@@ -54,6 +54,8 @@
 -define(SN_RC_INVALID_TOPIC_ID, 16#02).
 -define(SN_RC_NOT_SUPPORTED,    16#03).
 
+-define(QOS_NEG1, 3).
+
 -type(mqtt_sn_return_code() :: ?SN_RC_ACCECPTED .. ?SN_RC_NOT_SUPPORTED).
 
 %%--------------------------------------------------------------------

--- a/intergration_test/Makefile
+++ b/intergration_test/Makefile
@@ -21,7 +21,7 @@ PAHO_SRC  = paho.mqtt-sn.embedded-c/MQTTSNPacket/src/MQTTSNConnectClient.c      
 INCLUDE_PATH = -Ipaho.mqtt-sn.embedded-c/MQTTSNPacket/src -Ipaho.mqtt-sn.embedded-c/MQTTSNPacket/samples -Iclient
 			
 
-all:  clean_result $(RELX_CONF) $(PAHO_GIT) start_broker case1 case2 case3 stop_broker
+all:  clean_result $(RELX_CONF) $(PAHO_GIT) start_broker case1 case2 case3 case4 case5 stop_broker
 	@echo "  "
 	@echo "  test complete"
 	@echo "  "
@@ -67,6 +67,24 @@ case3:
 	client/case3_qos0sub.exe &
 	sleep 1
 	client/case3_qos0pub.exe
+
+case4:
+	-ps aux|grep case4_qos3pub|awk '{print $$2}'|xargs kill -9
+	-ps aux|grep case4_qos3sub|awk '{print $$2}'|xargs kill -9
+	gcc client/case4_qos3pub.c $(PAHO_SRC) $(INCLUDE_PATH) -o client/case4_qos3pub.exe
+	gcc client/case4_qos3sub.c $(PAHO_SRC) $(INCLUDE_PATH) -o client/case4_qos3sub.exe
+	client/case4_qos3sub.exe &
+	sleep 1
+	client/case4_qos3pub.exe
+
+case5:
+	-ps aux|grep case5_qos3pub|awk '{print $$2}'|xargs kill -9
+	-ps aux|grep case5_qos3sub|awk '{print $$2}'|xargs kill -9
+	gcc client/case5_qos3pub.c $(PAHO_SRC) $(INCLUDE_PATH) -o client/case5_qos3pub.exe
+	gcc client/case5_qos3sub.c $(PAHO_SRC) $(INCLUDE_PATH) -o client/case5_qos3sub.exe
+	client/case5_qos3sub.exe &
+	sleep 1
+	client/case5_qos3pub.exe
 	
 	
 	

--- a/intergration_test/Makefile
+++ b/intergration_test/Makefile
@@ -21,7 +21,7 @@ PAHO_SRC  = paho.mqtt-sn.embedded-c/MQTTSNPacket/src/MQTTSNConnectClient.c      
 INCLUDE_PATH = -Ipaho.mqtt-sn.embedded-c/MQTTSNPacket/src -Ipaho.mqtt-sn.embedded-c/MQTTSNPacket/samples -Iclient
 			
 
-all:  clean_result $(RELX_CONF) $(PAHO_GIT) start_broker case1 case2 case3 case4 case5 stop_broker
+all:  clean_result $(RELX_CONF) $(PAHO_GIT) start_broker case4 case5 stop_broker disable_qos3
 	@echo "  "
 	@echo "  test complete"
 	@echo "  "
@@ -39,7 +39,9 @@ start_broker:
 	
 stop_broker:
 	emq-relx/_rel/emqttd/bin/emqttd stop
-	
+
+disable_qos3:
+	python ./disable_qos3.py
 
 case1:
 	-ps aux|grep case1_qos0pub|awk '{print $$2}'|xargs kill -9
@@ -128,6 +130,7 @@ rebuild_emq:
 	cp -rf ../priv     emq-relx/deps/emq_sn/
 	cp -rf ../src      emq-relx/deps/emq_sn/
 	cp -rf ../Makefile emq-relx/deps/emq_sn/Makefile
+	python ./enable_qos3.py
 	make -C emq-relx -f Makefile
 	
 	

--- a/intergration_test/README.md
+++ b/intergration_test/README.md
@@ -1,12 +1,12 @@
 Integration test for emq-sn
 ======
 
-##execute following command
+## execute following command
 ```
 make
 ```
 
-##note
+## note
 
 The case4 and case5 are about processing publish message with qos=-1, which needs the mqtt.sn.enable_qos3 in the emq_sn.conf to set to on, otherwise these two cases may not get correct return value.
 

--- a/intergration_test/README.md
+++ b/intergration_test/README.md
@@ -6,3 +6,7 @@ execute following command
 make
 ```
 
+note
+
+The case4 and case5 are about processing publish message with qos=-1, which needs the mqtt.sn.enable_qos3 in the emq_sn.conf to set to on, otherwise these two cases may not get correct return value.
+

--- a/intergration_test/README.md
+++ b/intergration_test/README.md
@@ -8,5 +8,5 @@ make
 
 ## note
 
-The case4 and case5 are about processing publish message with qos=-1, which needs the mqtt.sn.enable_qos3 in the emq_sn.conf to set to on, otherwise these two cases may not get correct return value.
+The case4 and case5 are about processing received publish message with qos=-1, which needs the mqtt.sn.enable_qos3 in the emq_sn.conf to set to on, otherwise these two cases may not get correct return value. And we already have python script to set the mqtt.sn.enable_qos3 to be on automatically, all the user needs to do is to use command "make r" to rebuild before using command "make" to start the test.
 

--- a/intergration_test/README.md
+++ b/intergration_test/README.md
@@ -1,12 +1,12 @@
 Integration test for emq-sn
 ======
 
-execute following command
+##execute following command
 ```
 make
 ```
 
-note
+##note
 
 The case4 and case5 are about processing publish message with qos=-1, which needs the mqtt.sn.enable_qos3 in the emq_sn.conf to set to on, otherwise these two cases may not get correct return value.
 

--- a/intergration_test/client/case4_qos3pub.c
+++ b/intergration_test/client/case4_qos3pub.c
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Ian Craggs - initial API and implementation and/or initial documentation
+ *    Sergio R. Caprile - clarifications and/or documentation extension
+ *
+ * Description:
+ * Short topic name used to avoid registration process
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdarg.h>
+
+#include "MQTTSNPacket.h"
+#include "transport.h"
+
+#include "int_test_result.h"
+
+
+#define TLOG(fmt, ...)  tlog("qos0pub", fmt,  ## __VA_ARGS__)
+#define PRE_DEF_TOPIC_ID 1
+
+
+int send_pub(char *host, int port, char * buf, int buflen, int qos, int retained, short packetid, unsigned short predef_topicid, char *payload, int payloadlen)
+{
+    MQTTSN_topicid topic;
+    int rc = 0;
+    int len = 0;
+    int dup = 0;
+    
+    /* publish with short name */
+    topic.type = MQTTSN_TOPIC_TYPE_PREDEFINED;
+    topic.data.id = predef_topicid;
+    len = MQTTSNSerialize_publish(buf, buflen, dup, qos, retained, packetid,
+            topic, payload, payloadlen);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    TLOG("rc %d from send packet %s for publish topictype %d topicid %d length %d\n", rc, payload, topic.type, topic.data.id, len);
+    
+    return rc;
+}
+
+
+
+int main(int argc, char** argv)
+{
+    int rc = 0;
+    int mysock;
+    unsigned char buf[200];
+    int buflen = sizeof(buf);
+    
+    unsigned char payload[16];
+    int payloadlen = 0;
+    int len = 0;
+    int qos = 3;
+    int retained = 0;
+    short packetid = 0;
+    char ascii = 0;
+//  char *topicname = "a long topic name";
+    unsigned short predef_topicid = PRE_DEF_TOPIC_ID;
+    char *host = "127.0.0.1";
+    int port = 1884;
+    int i = 0;
+    MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
+
+    mysock = transport_open();
+    if(mysock < 0)
+        return mysock;
+
+    if (argc > 1)
+        host = argv[1];
+
+    if (argc > 2)
+        port = atoi(argv[2]);
+
+    TLOG("Sending to hostname %s port %d\n", host, port);
+#if 0
+    options.clientID.cstring = "pubpredef0 MQTT-SN";
+    len = MQTTSNSerialize_connect(buf, buflen, &options);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    /* wait for connack */
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_CONNACK)
+    {
+        int connack_rc = -1;
+
+        if (MQTTSNDeserialize_connack(&connack_rc, buf, buflen) != 1 || connack_rc != 0)
+        {
+            TLOG("Unable to connect, return code %d\n", connack_rc);
+            goto exit;
+        }
+        else 
+            TLOG("connected rc %d\n", connack_rc);
+    }
+    else
+        goto exit;
+#endif
+    for(i=0;i<2;i++)
+    {
+        unsigned short topicid = predef_topicid+i;
+        ascii = 'a'+(i%26);
+        payload[0] = payload[1] = payload[2] = ascii;
+        payload[3] = 0;
+        payloadlen = 4;
+        send_pub(host, port, buf, buflen, qos, retained, packetid, topicid, payload, payloadlen);
+        TLOG("%d send publish %s", i, payload);
+        sleep(1);
+    }
+
+exit:
+    transport_close();
+
+    return 0;
+}
+
+
+
+

--- a/intergration_test/client/case4_qos3sub.c
+++ b/intergration_test/client/case4_qos3sub.c
@@ -1,0 +1,222 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Ian Craggs - initial API and implementation and/or initial documentation
+ *    Sergio R. Caprile - clarifications and/or documentation extension
+ *
+ * Description:
+ * Normal topic name is automatically registered at subscription, then
+ * a message is published and the node receives it itself
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include "MQTTSNPacket.h"
+#include "transport.h"
+
+#include "int_test_result.h"
+
+
+
+#define TLOG(fmt, ...)  tlog("qos0sub", fmt,  ## __VA_ARGS__)
+#define PRE_DEF_TOPIC_ID 1
+
+
+char * read_publish(char *host, int port, char * buf, int buflen, MQTTSN_topicid *recv_pubtopic)
+{
+    int rc = 0;
+    int len = 0;
+    
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_PUBLISH)
+    {
+        unsigned short packet_id;
+        int qos, payloadlen;
+        unsigned char* payload = NULL;
+        unsigned char dup, retained;
+        MQTTSN_topicid pubtopic;
+
+        if (MQTTSNDeserialize_publish(&dup, &qos, &retained, &packet_id, &pubtopic,
+                &payload, &payloadlen, buf, buflen) != 1)
+            TLOG("Error deserializing publish\n");
+        else 
+            TLOG("publish received, packet_id %d qos %d topictype %d topicid %d\n", packet_id, qos, pubtopic.type, pubtopic.data.id);
+        
+        recv_pubtopic->type = pubtopic.type;
+        recv_pubtopic->data.id = pubtopic.data.id;
+
+        if (qos == 1)
+        {
+            len = MQTTSNSerialize_puback(buf, buflen, pubtopic.data.id, packet_id, MQTTSN_RC_ACCEPTED);
+            rc = transport_sendPacketBuffer(host, port, buf, len);
+            if (rc == 0)
+                TLOG("puback sent\n");
+        }
+        
+        return payload;
+    }
+    
+    return NULL;
+}
+
+
+int main(int argc, char** argv)
+{
+    int rc = 0;
+    int mysock;
+    unsigned char buf[200];
+    int buflen = sizeof(buf);
+    MQTTSN_topicid topic;
+    char  expect_payload[16];
+    int len = 0;
+    int i = 0;
+    unsigned char dup = 0;
+    int qos = 0;
+    unsigned char retained = 0;
+    short packetid = 1;
+    //char *topicname = "predef_topic1";
+    unsigned short predef_topicid1 = PRE_DEF_TOPIC_ID;
+    unsigned short predef_topicid2 = PRE_DEF_TOPIC_ID+1;
+    char *host = "127.0.0.1";
+    int port = 1884;
+    MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
+    unsigned short topicid;
+    char * recv_payload = NULL;
+    char   final_result = RESULT_PASS;
+
+    mysock = transport_open();
+    if(mysock < 0)
+        return mysock;
+
+    if (argc > 1)
+        host = argv[1];
+
+    if (argc > 2)
+        port = atoi(argv[2]);
+
+    TLOG("Sending to hostname %s port %d\n", host, port);
+
+    options.clientID.cstring = "subpredef0 MQTT-SN";
+    len = MQTTSNSerialize_connect(buf, buflen, &options);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    /* wait for connack */
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_CONNACK)
+    {
+        int connack_rc = -1;
+
+        if (MQTTSNDeserialize_connack(&connack_rc, buf, buflen) != 1 || connack_rc != 0)
+        {
+            TLOG("Unable to connect, return code %d\n", connack_rc);
+            goto exit;
+        }
+        else 
+            TLOG("connected rc %d\n", connack_rc);
+    }
+    else
+        goto exit;
+
+
+    /* subscribe */
+    TLOG("Subscribing to predef_topicid1\n");
+    topic.type = MQTTSN_TOPIC_TYPE_PREDEFINED;
+    topic.data.id = predef_topicid1;
+    len = MQTTSNSerialize_subscribe(buf, buflen, 0, qos, packetid, &topic);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_SUBACK)     /* wait for suback */
+    {
+        unsigned short submsgid;
+        int granted_qos;
+        unsigned char returncode;
+
+        rc = MQTTSNDeserialize_suback(&granted_qos, &predef_topicid1, &submsgid, &returncode, buf, buflen);
+        if (granted_qos != 0 || returncode != 0)
+        {
+            TLOG("granted qos != 2, %d return code %d\n", granted_qos, returncode);
+            goto exit;
+        }
+        else
+            TLOG("suback topic id %d\n", predef_topicid1);
+    }
+    else
+        goto exit;
+
+    packetid = 2;
+    TLOG("Subscribing to predef_topicid2\n");
+    topic.type = MQTTSN_TOPIC_TYPE_PREDEFINED;
+    topic.data.id = predef_topicid2;
+    len = MQTTSNSerialize_subscribe(buf, buflen, 0, qos, packetid, &topic);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_SUBACK)     /* wait for suback */
+    {
+        unsigned short submsgid;
+        int granted_qos;
+        unsigned char returncode;
+
+        rc = MQTTSNDeserialize_suback(&granted_qos, &predef_topicid2, &submsgid, &returncode, buf, buflen);
+        if (granted_qos != 0 || returncode != 0)
+        {
+            TLOG("granted qos != 2, %d return code %d\n", granted_qos, returncode);
+            goto exit;
+        }
+        else
+            TLOG("suback topic id %d\n", predef_topicid2);
+    }
+    else
+        goto exit;
+
+    /*receive publish*/
+    TLOG("Receive publish\n");
+    for(i=0;i<2;i++)
+    {
+        MQTTSN_topicid pubtopic = {0};
+        char ascii = 'a'+(i%26);
+        expect_payload[0] = expect_payload[1] = expect_payload[2] = ascii;
+        expect_payload[3] = 0;
+        recv_payload = read_publish(host, port, buf, buflen, &pubtopic);
+        if( recv_payload )
+        {
+            TLOG("case1_qos0sub %d receive %s\n", i, recv_payload);
+            if( strcmp(recv_payload, expect_payload) != 0 )
+            {
+                final_result = RESULT_FAIL;
+                break;
+            }
+        }
+        if((pubtopic.type != MQTTSN_TOPIC_TYPE_PREDEFINED) || (pubtopic.data.id != predef_topicid1+i))
+        {
+            final_result = RESULT_FAIL;
+            break;
+        }
+        sleep(1);
+    }
+    
+
+    len = MQTTSNSerialize_disconnect(buf, buflen, 0);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+exit:
+    transport_close();
+
+    mark_result(argv[0], final_result);
+    
+    return 0;
+}
+
+
+
+

--- a/intergration_test/client/case5_qos3pub.c
+++ b/intergration_test/client/case5_qos3pub.c
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Ian Craggs - initial API and implementation and/or initial documentation
+ *    Sergio R. Caprile - clarifications and/or documentation extension
+ *
+ * Description:
+ * Short topic name used to avoid registration process
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdarg.h>
+
+#include "MQTTSNPacket.h"
+#include "transport.h"
+
+#include "int_test_result.h"
+
+
+#define TLOG(fmt, ...)  tlog("qos0pub", fmt,  ## __VA_ARGS__)
+#define SHORT_TOPIC "ST"
+
+
+int send_pub(char *host, int port, char * buf, int buflen, int qos, int retained, short packetid, char *payload, int payloadlen)
+{
+    MQTTSN_topicid topic;
+    int rc = 0;
+    int len = 0;
+    int dup = 0;
+    
+    /* publish with short name */
+    topic.type = MQTTSN_TOPIC_TYPE_SHORT;
+    memcpy(topic.data.short_name, SHORT_TOPIC, 2);
+    len = MQTTSNSerialize_publish(buf, buflen, dup, qos, retained, packetid,
+            topic, payload, payloadlen);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    TLOG("rc %d from send packet %s for publish topictype %d topicid %d length %d\n", rc, payload, topic.type, topic.data.id, len);
+    
+    return rc;
+}
+
+
+
+int main(int argc, char** argv)
+{
+    int rc = 0;
+    int mysock;
+    unsigned char buf[200];
+    int buflen = sizeof(buf);
+    
+    unsigned char payload[16];
+    int payloadlen = 0;
+    int len = 0;
+    int qos = 3;
+    int retained = 0;
+    short packetid = 0;
+    char ascii = 0;
+//  char *topicname = "a long topic name";
+    char *host = "127.0.0.1";
+    int port = 1884;
+    int i = 0;
+    MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
+
+    mysock = transport_open();
+    if(mysock < 0)
+        return mysock;
+
+    if (argc > 1)
+        host = argv[1];
+
+    if (argc > 2)
+        port = atoi(argv[2]);
+
+    TLOG("Sending to hostname %s port %d\n", host, port);
+
+    options.clientID.cstring = "pubpredef0 MQTT-SN";
+    len = MQTTSNSerialize_connect(buf, buflen, &options);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    /* wait for connack */
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_CONNACK)
+    {
+        int connack_rc = -1;
+
+        if (MQTTSNDeserialize_connack(&connack_rc, buf, buflen) != 1 || connack_rc != 0)
+        {
+            TLOG("Unable to connect, return code %d\n", connack_rc);
+            goto exit;
+        }
+        else 
+            TLOG("connected rc %d\n", connack_rc);
+    }
+    else
+        goto exit;
+
+    for(i=0;i<2;i++)
+    {
+        ascii = 'a'+(i%26);
+        payload[0] = payload[1] = payload[2] = ascii;
+        payload[3] = 0;
+        payloadlen = 4;
+        send_pub(host, port, buf, buflen, qos, retained, packetid, payload, payloadlen);
+        TLOG("%d send publish %s", i, payload);
+        sleep(1);
+    }
+
+exit:
+    transport_close();
+
+    return 0;
+}
+
+
+
+

--- a/intergration_test/client/case5_qos3sub.c
+++ b/intergration_test/client/case5_qos3sub.c
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2014 IBM Corp.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Ian Craggs - initial API and implementation and/or initial documentation
+ *    Sergio R. Caprile - clarifications and/or documentation extension
+ *
+ * Description:
+ * Normal topic name is automatically registered at subscription, then
+ * a message is published and the node receives it itself
+ *******************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include "MQTTSNPacket.h"
+#include "transport.h"
+
+#include "int_test_result.h"
+
+
+
+#define TLOG(fmt, ...)  tlog("qos0sub", fmt,  ## __VA_ARGS__)
+#define SHORT_TOPIC "ST"
+
+
+char * read_publish(char *host, int port, char * buf, int buflen, MQTTSN_topicid *recv_pubtopic)
+{
+    int rc = 0;
+    int len = 0;
+    
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_PUBLISH)
+    {
+        unsigned short packet_id;
+        int qos, payloadlen;
+        unsigned char* payload = NULL;
+        unsigned char dup, retained;
+        MQTTSN_topicid pubtopic;
+
+        if (MQTTSNDeserialize_publish(&dup, &qos, &retained, &packet_id, &pubtopic,
+                &payload, &payloadlen, buf, buflen) != 1)
+            TLOG("Error deserializing publish\n");
+        else 
+            TLOG("publish received, packet_id %d qos %d topictype %d topicid %d\n", packet_id, qos, pubtopic.type, pubtopic.data.id);
+        
+        recv_pubtopic->type = pubtopic.type;
+        memcpy(recv_pubtopic->data.short_name, pubtopic.data.short_name, 2);
+
+        if (qos == 1)
+        {
+            len = MQTTSNSerialize_puback(buf, buflen, pubtopic.data.id, packet_id, MQTTSN_RC_ACCEPTED);
+            rc = transport_sendPacketBuffer(host, port, buf, len);
+            if (rc == 0)
+                TLOG("puback sent\n");
+        }
+        
+        return payload;
+    }
+    
+    return NULL;
+}
+
+
+int main(int argc, char** argv)
+{
+    int rc = 0;
+    int mysock;
+    unsigned char buf[200];
+    int buflen = sizeof(buf);
+    MQTTSN_topicid topic;
+    char  expect_payload[16];
+    int len = 0;
+    int i = 0;
+    unsigned char dup = 0;
+    int qos = 0;
+    unsigned char retained = 0;
+    short packetid = 1;
+    //char *topicname = "predef_topic1";
+    char *host = "127.0.0.1";
+    int port = 1884;
+    MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
+    unsigned short topicid;
+    char * recv_payload = NULL;
+    char   final_result = RESULT_PASS;
+
+    mysock = transport_open();
+    if(mysock < 0)
+        return mysock;
+
+    if (argc > 1)
+        host = argv[1];
+
+    if (argc > 2)
+        port = atoi(argv[2]);
+
+    TLOG("Sending to hostname %s port %d\n", host, port);
+
+    options.clientID.cstring = "subpredef0 MQTT-SN";
+    len = MQTTSNSerialize_connect(buf, buflen, &options);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    /* wait for connack */
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_CONNACK)
+    {
+        int connack_rc = -1;
+
+        if (MQTTSNDeserialize_connack(&connack_rc, buf, buflen) != 1 || connack_rc != 0)
+        {
+            TLOG("Unable to connect, return code %d\n", connack_rc);
+            goto exit;
+        }
+        else 
+            TLOG("connected rc %d\n", connack_rc);
+    }
+    else
+        goto exit;
+
+
+    /* subscribe */
+    TLOG("Subscribing to predef_topicid1\n");
+    topic.type = MQTTSN_TOPIC_TYPE_SHORT;
+    memcpy(topic.data.short_name, SHORT_TOPIC, 2);
+    len = MQTTSNSerialize_subscribe(buf, buflen, 0, qos, packetid, &topic);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+    if (MQTTSNPacket_read(buf, buflen, transport_getdata) == MQTTSN_SUBACK)     /* wait for suback */
+    {
+        unsigned short submsgid;
+        int granted_qos;
+        unsigned char returncode;
+
+        rc = MQTTSNDeserialize_suback(&granted_qos, &topicid, &submsgid, &returncode, buf, buflen);
+        if (granted_qos != 0 || returncode != 0)
+        {
+            TLOG("granted qos != 2, %d return code %d\n", granted_qos, returncode);
+            goto exit;
+        }
+        else
+            TLOG("suback topic id %d\n", topicid);
+    }
+    else
+        goto exit;
+
+    /*receive publish*/
+    TLOG("Receive publish\n");
+    for(i=0;i<2;i++)
+    {
+        MQTTSN_topicid pubtopic = {0};
+        char ascii = 'a'+(i%26);
+        expect_payload[0] = expect_payload[1] = expect_payload[2] = ascii;
+        expect_payload[3] = 0;
+        recv_payload = read_publish(host, port, buf, buflen, &pubtopic);
+        if( recv_payload )
+        {
+            TLOG("case1_qos0sub %d receive %s\n", i, recv_payload);
+            if( strcmp(recv_payload, expect_payload) != 0 )
+            {
+                final_result = RESULT_FAIL;
+                break;
+            }
+        }
+        if((pubtopic.type != MQTTSN_TOPIC_TYPE_SHORT) || (memcmp(pubtopic.data.short_name, SHORT_TOPIC, 2)))
+        {
+            final_result = RESULT_FAIL;
+            break;
+        }
+        sleep(1);
+    }
+    
+
+    len = MQTTSNSerialize_disconnect(buf, buflen, 0);
+    rc = transport_sendPacketBuffer(host, port, buf, len);
+
+exit:
+    transport_close();
+
+    mark_result(argv[0], final_result);
+    
+    return 0;
+}
+
+
+
+

--- a/intergration_test/disable_qos3.py
+++ b/intergration_test/disable_qos3.py
@@ -1,0 +1,17 @@
+
+input = open("emq-relx/deps/emq_sn/etc/emq_sn.conf")
+lines = input.readlines()
+input.close()
+
+output  = open("emq-relx/deps/emq_sn/etc/emq_sn.conf",'w');
+for line in lines:
+    if not line:
+        break
+    if 'enable_qos3' in line:
+        line = line.replace('on','off')
+        output.write(line)
+    else:
+        output.write(line)
+output.close()
+
+

--- a/intergration_test/enable_qos3.py
+++ b/intergration_test/enable_qos3.py
@@ -1,0 +1,17 @@
+
+input = open("emq-relx/deps/emq_sn/etc/emq_sn.conf")
+lines = input.readlines()
+input.close()
+
+output  = open("emq-relx/deps/emq_sn/etc/emq_sn.conf",'w');
+for line in lines:
+    if not line:
+        break
+    if 'enable_qos3' in line:
+        line = line.replace('off','on')
+        output.write(line)
+    else:
+        output.write(line)
+output.close()
+
+

--- a/priv/emq_sn.schema
+++ b/priv/emq_sn.schema
@@ -27,6 +27,10 @@
   {datatype, flag}
 ]}.
 
+{mapping, "mqtt.sn.enable_qos3", "emq_sn.enable_qos3", [
+  {datatype, flag}
+]}.
+
 {mapping, "mqtt.sn.predefined.topic.$id", "emq_sn.predefined", [
   {datatype, string}
 ]}.

--- a/src/emq_sn_gateway.erl
+++ b/src/emq_sn_gateway.erl
@@ -473,11 +473,11 @@ handle_info({suback, MsgId, [GrantedQos]}, StateName, StateData=#state{awaiting_
     send_message(?SN_SUBACK_MSG(Flags, TopicId, MsgId, ?SN_RC_ACCECPTED), StateData#state.conn),
     next_state(StateName, StateData#state{awaiting_suback = lists:delete({MsgId, TopicId}, Awaiting)});
 
-handle_info({'$gen_cast', [{subscribe, Topics}]}, StateName, StateData) ->
+handle_info({'$gen_cast', {subscribe, [Topics]}}, StateName, StateData) ->
     ?LOG(debug, "ignore subscribe Topics=~p", [Topics], StateData),
     {next_state, StateName, StateData};
 
-handle_info({'$gen_event', [{subscribe, Topics}]}, StateName, StateData) ->
+handle_info({subscribe, [Topics]}, StateName, StateData) ->
     ?LOG(debug, "ignore subscribe Topics=~p", [Topics], StateData),
     {next_state, StateName, StateData};
 

--- a/src/emq_sn_gateway.erl
+++ b/src/emq_sn_gateway.erl
@@ -473,7 +473,11 @@ handle_info({suback, MsgId, [GrantedQos]}, StateName, StateData=#state{awaiting_
     send_message(?SN_SUBACK_MSG(Flags, TopicId, MsgId, ?SN_RC_ACCECPTED), StateData#state.conn),
     next_state(StateName, StateData#state{awaiting_suback = lists:delete({MsgId, TopicId}, Awaiting)});
 
-handle_info({'$gen_cast', {subscribe, Topics}}, StateName, StateData) ->
+handle_info({'$gen_cast', [{subscribe, Topics}]}, StateName, StateData) ->
+    ?LOG(debug, "ignore subscribe Topics=~p", [Topics], StateData),
+    {next_state, StateName, StateData};
+
+handle_info({'$gen_event', [{subscribe, Topics}]}, StateName, StateData) ->
     ?LOG(debug, "ignore subscribe Topics=~p", [Topics], StateData),
     {next_state, StateName, StateData};
 

--- a/src/emq_sn_gateway.erl
+++ b/src/emq_sn_gateway.erl
@@ -914,13 +914,10 @@ emit_stats(ClientId, #state{protocol=ProtoState, conn = #connection{socket = Soc
         socket_stats(Sock, ?SOCK_STATS)]),
     ?SET_CLIENT_STATS(ClientId, StatsList).
 
-get_corrected_qos(Qos, StateData) ->
-    case Qos =:= ?QOS_NEG1 of
-        true  ->
-            ?LOG(debug, "Receive a publish with Qos=-1", [], StateData),
-            ?QOS0;
-        false ->
-            Qos
-    end.
+get_corrected_qos(?QOS_NEG1, StateData) ->
+    ?LOG(debug, "Receive a publish with Qos=-1", [], StateData),
+    ?QOS0;
 
+get_corrected_qos(Qos, _StateData) ->
+    Qos.
 

--- a/src/emq_sn_gateway.erl
+++ b/src/emq_sn_gateway.erl
@@ -64,7 +64,8 @@
                 idle_timer = undefined      :: term(),
                 asleep_timer                :: tuple(),
                 asleep_msg_queue            :: term(),
-                enable_stats                :: boolean()}).
+                enable_stats                :: boolean(),
+                enable_qos3 = false         :: boolean()}).
 
 -define(LOG(Level, Format, Args, State),
             lager:Level("MQTT-SN(~s): " ++ Format,
@@ -94,6 +95,7 @@
 -endif.
 
 -define(SOCK_STATS, [recv_oct, recv_cnt, send_oct, send_cnt, send_pend]).
+-define(NEG_QOS_CLIENT_ID, <<"NegQos-Client">>).
 %%--------------------------------------------------------------------
 %% Exported APIs
 %%--------------------------------------------------------------------
@@ -128,7 +130,8 @@ init([Sock, Peer, GwId, EnableStats]) ->
                    protocol = ProtoState,
                    asleep_timer = emq_sn_asleep_timer:init(),
                    asleep_msg_queue = queue:new(),
-                   enable_stats = EnableStats},
+                   enable_stats = EnableStats,
+                   enable_qos3 = application:get_env(?APP, enable_qos3, false)},
     {ok, idle, State, 3000}.
 
 
@@ -170,6 +173,21 @@ idle(?SN_ADVERTISE_MSG(_GwId, _Radius), StateData) ->
 
 idle(?SN_DISCONNECT_MSG(_Duration), StateData) ->
     % ignore
+    {next_state, idle, StateData};
+
+idle(?SN_PUBLISH_MSG(_Flag, _TopicId, _MsgId, _Data), StateData = #state{enable_qos3 = false}) ->
+    ?LOG(debug, "The enable_qos3 is false, ignore the received publish with Qos=-1 in idle mode!", [], StateData),
+    {next_state, idle, StateData};
+
+idle(?SN_PUBLISH_MSG(#mqtt_sn_flags{qos = ?QOS_NEG1, topic_id_type = TopicIdType}, TopicId, _MsgId, Data), StateData = #state{client_id = ClientId}) ->
+    TopicName = case (TopicIdType =:= ?SN_SHORT_TOPIC) of
+                    false ->
+                        emq_sn_topic_manager:lookup_topic(ClientId, TopicId);
+                    true  ->
+                        <<TopicId:16>>
+                end,
+    (TopicName =/= undefined) andalso emqttd_server:publish(emqttd_message:make({?NEG_QOS_CLIENT_ID, application:get_env(?APP, username, undefined)}, ?QOS_0, TopicName, Data)),
+    ?LOG(debug, "Client id=~p receives a publish with Qos=-1 in idle mode!", [ClientId], StateData),
     {next_state, idle, StateData};
 
 idle(Event, StateData) ->
@@ -232,9 +250,16 @@ connected(?SN_REGISTER_MSG(_TopicId, MsgId, TopicName), StateData = #state{clien
     end,
     {next_state, connected, StateData};
 
-connected(?SN_PUBLISH_MSG(Flags, TopicId, MsgId, Data), StateData) ->
-    #mqtt_sn_flags{topic_id_type = TopicIdType} = Flags,
-    do_publish(TopicIdType, TopicId, Data, Flags, MsgId, StateData);
+connected(?SN_PUBLISH_MSG(Flags, TopicId, MsgId, Data), StateData = #state{enable_qos3 = EnableQos3}) ->
+    #mqtt_sn_flags{topic_id_type = TopicIdType, qos = Qos} = Flags,
+    Skip = (EnableQos3 =:= false) andalso (Qos =:= ?QOS_NEG1),
+    case Skip of
+        true  ->
+            ?LOG(debug, "The enable_qos3 is false, ignore the received publish with Qos=-1 in connected mode!", [], StateData),
+            next_state(connected, StateData);
+        false ->
+            do_publish(TopicIdType, TopicId, Data, Flags, MsgId, StateData)
+    end;
 
 connected(?SN_PUBACK_MSG(TopicId, MsgId, ReturnCode), StateData) ->
     do_puback(TopicId, MsgId, ReturnCode, connected, StateData);
@@ -368,19 +393,6 @@ asleep(Event, _From, StateData) ->
 awake(Event, _From, StateData) ->
     ?LOG(error, "UNEXPECTED Event: ~p", [Event], StateData),
     {reply, ignored, awake, StateData}.
-
-emit_stats(StateData=#state{protocol=ProtoState}) ->
-    emit_stats(?PROTO_GET_CLIENT_ID(ProtoState), StateData).
-
-emit_stats(_ClientId, State = #state{enable_stats = false}) ->
-    ?LOG(debug, "The enable_stats is false, skip emit_state~n", [], State),
-    State;
-
-emit_stats(ClientId, #state{protocol=ProtoState, conn = #connection{socket = Sock}}) ->
-    StatsList = lists:append([emqttd_misc:proc_stats(),
-        ?PROTO_STATS(ProtoState),
-        socket_stats(Sock, ?SOCK_STATS)]),
-    ?SET_CLIENT_STATS(ClientId, StatsList).
 
 socket_stats(Sock, Stats) when is_port(Sock), is_list(Stats)->
     inet:getstat(Sock, Stats).
@@ -699,22 +711,36 @@ do_publish(?SN_NORMAL_TOPIC, TopicId, Data, Flags, MsgId, StateData) ->
     do_publish(?SN_PREDEFINED_TOPIC, TopicId, Data, Flags, MsgId, StateData);
 do_publish(?SN_PREDEFINED_TOPIC, TopicId, Data, Flags, MsgId, StateData=#state{client_id = ClientId}) ->
     #mqtt_sn_flags{qos = Qos, dup = Dup, retain = Retain} = Flags,
+    NewQos = case Qos =:= ?QOS_NEG1 of
+                 true  ->
+                     ?LOG(debug, "Receive a publish with Qos=-1", [], StateData),
+                     ?QOS0;
+                 false ->
+                     Qos
+             end,
     case emq_sn_topic_manager:lookup_topic(ClientId, TopicId) of
         undefined ->
-            (Qos =/= ?QOS0) andalso send_message(?SN_PUBACK_MSG(TopicId, MsgId, ?SN_RC_INVALID_TOPIC_ID), StateData#state.conn),
+            (NewQos =/= ?QOS0) andalso send_message(?SN_PUBACK_MSG(TopicId, MsgId, ?SN_RC_INVALID_TOPIC_ID), StateData#state.conn),
             next_state(connected, StateData);
         TopicName ->
-            proto_publish(TopicName, Data, Dup, Qos, Retain, MsgId, TopicId, StateData)
+            proto_publish(TopicName, Data, Dup, NewQos, Retain, MsgId, TopicId, StateData)
     end;
 do_publish(?SN_SHORT_TOPIC, TopicId, Data, Flags, MsgId, StateData) ->
     #mqtt_sn_flags{qos = Qos, dup = Dup, retain = Retain} = Flags,
+    NewQos = case Qos =:= ?QOS_NEG1 of
+                 true  ->
+                     ?LOG(debug, "Receive a publish with Qos=-1", [], StateData),
+                     ?QOS0;
+                 false ->
+                     Qos
+             end,
     TopicName = <<TopicId:16>>,
     case emq_sn_topic_manager:wildcard(TopicName) of
         true ->
-            (Qos =/= ?QOS0) andalso send_message(?SN_PUBACK_MSG(TopicId, MsgId, ?SN_RC_NOT_SUPPORTED), StateData#state.conn),
+            (NewQos =/= ?QOS0) andalso send_message(?SN_PUBACK_MSG(TopicId, MsgId, ?SN_RC_NOT_SUPPORTED), StateData#state.conn),
             next_state(connected, StateData);
         false ->
-            proto_publish(TopicName, Data, Dup, Qos, Retain, MsgId, TopicId, StateData)
+            proto_publish(TopicName, Data, Dup, NewQos, Retain, MsgId, TopicId, StateData)
     end;
 do_publish(_, TopicId, _Data, #mqtt_sn_flags{qos = Qos}, MsgId, StateData) ->
     (Qos =/= ?QOS0) andalso send_message(?SN_PUBACK_MSG(TopicId, MsgId, ?SN_RC_NOT_SUPPORTED), StateData#state.conn),
@@ -886,5 +912,19 @@ is_qos2_msg(#mqtt_message{qos = 2})->
     true;
 is_qos2_msg(#mqtt_message{})->
     false.
+
+emit_stats(StateData=#state{protocol=ProtoState}) ->
+    emit_stats(?PROTO_GET_CLIENT_ID(ProtoState), StateData).
+
+emit_stats(_ClientId, State = #state{enable_stats = false}) ->
+    ?LOG(debug, "The enable_stats is false, skip emit_state~n", [], State),
+    State;
+
+emit_stats(ClientId, #state{protocol=ProtoState, conn = #connection{socket = Sock}}) ->
+    StatsList = lists:append([emqttd_misc:proc_stats(),
+        ?PROTO_STATS(ProtoState),
+        socket_stats(Sock, ?SOCK_STATS)]),
+    ?SET_CLIENT_STATS(ClientId, StatsList).
+
 
 

--- a/test/emq_sn_protocol_SUITE.erl
+++ b/test/emq_sn_protocol_SUITE.erl
@@ -39,7 +39,7 @@
 -define(PREDEF_TOPIC_ID2, 2).
 -define(PREDEF_TOPIC_NAME1, <<"/predefined/topic/name/hello">>).
 -define(PREDEF_TOPIC_NAME2, <<"/predefined/topic/name/nice">>).
--define(ENABLE_QOS3, false).
+-define(ENABLE_QOS3, true).
 % FLAG NOT USED
 -define(FNU, 0).
 

--- a/test/emq_sn_protocol_SUITE.erl
+++ b/test/emq_sn_protocol_SUITE.erl
@@ -34,19 +34,22 @@
 -define(LOG(Format, Args),
     lager:debug("TEST SUITE: " ++ Format, Args)).
 
-% FLAG NOT USED
--define(FNU, 0).
 -define(MAX_PRED_TOPIC_ID, 2).
 -define(PREDEF_TOPIC_ID1, 1).
 -define(PREDEF_TOPIC_ID2, 2).
 -define(PREDEF_TOPIC_NAME1, <<"/predefined/topic/name/hello">>).
 -define(PREDEF_TOPIC_NAME2, <<"/predefined/topic/name/nice">>).
+-define(ENABLE_QOS3, false).
+% FLAG NOT USED
+-define(FNU, 0).
+
 all() -> [
     subscribe_test, subscribe_test1, subscribe_test2, subscribe_test3, subscribe_test4,
     subscribe_test10, subscribe_test11, subscribe_test12, subscribe_test13,
     publish_qos0_test1, publish_qos0_test2, publish_qos0_test3, publish_qos0_test4, publish_qos0_test5, publish_qos0_test6,
     publish_qos1_test1, publish_qos1_test2, publish_qos1_test3, publish_qos1_test4, publish_qos1_test5, publish_qos1_test6,
     publish_qos2_test1, publish_qos2_test2, publish_qos2_test3,
+    publish_negqos_test1,
     will_test1, will_test2, will_test3, will_test4, will_test5,
     broadcast_test1,
     asleep_test01_timeout, asleep_test02_to_awake_and_back,
@@ -67,6 +70,7 @@ end_per_suite(_Config) ->
 
 init_per_testcase(_TestCase, Config) ->
     %application:set_env(emq_sn, advertise_duration, 2),
+    application:set_env(emq_sn, enable_qos3, ?ENABLE_QOS3),
     application:set_env(emq_sn, enable_stats, true),
     application:set_env(emq_sn, username, <<"user1">>),
     application:set_env(emq_sn, password, <<"pw123">>),
@@ -394,6 +398,48 @@ subscribe_test13(_Config) ->
     ?assertEqual(<<8, ?SN_SUBACK, Dup:1, Qos:2, Retain:1, Will:1, CleanSession:1, ?SN_NORMAL_TOPIC:2, ?SN_INVALID_TOPIC_ID:16, MsgId:16, ?SN_RC_INVALID_TOPIC_ID>>,
         receive_response(Socket)),
     ?assertEqual(undefined, test_mqtt_broker:get_subscrbied_topic()),
+
+    send_disconnect_msg(Socket, undefined),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+    gen_udp:close(Socket),
+    test_mqtt_broker:stop().
+
+
+publish_negqos_test1(_Config) ->
+    test_mqtt_broker:start_link(),
+    Dup = 0,
+    Qos = 0,
+    NegQos = 3,
+    Retain = 0,
+    Will = 0,
+    CleanSession = 0,
+    MsgId = 1,
+    TopicId1 = ?MAX_PRED_TOPIC_ID + 1,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    send_connect_msg(Socket, <<"test">>),
+    ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+    Topic = <<"abc">>,
+    send_subscribe_msg_normal_topic(Socket, Qos, Topic, MsgId),
+    ?assertEqual(<<8, ?SN_SUBACK, Dup:1, Qos:2, Retain:1, Will:1, CleanSession:1, ?SN_NORMAL_TOPIC:2, TopicId1:16, MsgId:16, ?SN_RC_ACCECPTED>>,
+        receive_response(Socket)),
+    ?assertEqual(Topic, test_mqtt_broker:get_subscrbied_topic()),
+
+    MsgId1 = 3,
+    RetainFalse = false,
+    Payload1 = <<20, 21, 22, 23>>,
+    send_publish_msg_normal_topic(Socket, NegQos, MsgId1, TopicId1, Payload1),
+    timer:sleep(100),
+    case ?ENABLE_QOS3 of
+        true  ->
+            ?assertEqual({MsgId1, Qos, RetainFalse, Topic, Payload1}, test_mqtt_broker:get_published_msg()),
+            test_mqtt_broker:dispatch(MsgId1, Qos, RetainFalse, Topic, Payload1),
+            Eexp = <<11, ?SN_PUBLISH, Dup:1, Qos:2, Retain:1, Will:1, CleanSession:1, ?SN_NORMAL_TOPIC:2, TopicId1:16, (mid(0)):16, <<20, 21, 22, 23>>/binary>>,
+            What = receive_response(Socket),
+            ?assertEqual(Eexp, What);
+        false ->
+            ?assertEqual({undefined, undefined, undefined, undefined, undefined}, test_mqtt_broker:get_published_msg())
+    end,
 
     send_disconnect_msg(Socket, undefined),
     ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),


### PR DESCRIPTION
In both idle and connected mode, emq_sn_gateway can accept and process received publish message with qos=-1(actually the qos integer value is 3), only when the flag variable mqtt.sn.enable_qos3 in emq_sn.conf is set to on. If the mqtt.sn.enable_qos3 is set to off, we will just discard the received publish message.