### PR TITLE
Fix crash in emq_sn_gateway:transform() function which handles SUBACK

### DIFF
--- a/include/emq_sn.hrl
+++ b/include/emq_sn.hrl
@@ -54,6 +54,8 @@
 -define(SN_RC_INVALID_TOPIC_ID, 16#02).
 -define(SN_RC_NOT_SUPPORTED,    16#03).
 
+-define(SN_RC_MQTT_FAILURE,     16#80).
+
 -define(QOS_NEG1, 3).
 
 -type(mqtt_sn_return_code() :: ?SN_RC_ACCECPTED .. ?SN_RC_NOT_SUPPORTED).

--- a/intergration_test/Makefile
+++ b/intergration_test/Makefile
@@ -29,6 +29,7 @@ all:  clean_result $(RELX_CONF) $(PAHO_GIT) start_broker case1 case2 case3 case4
 clean_result:
 	-rm -f client/*_FAIL.txt
 	-rm -f client/*_PASS.txt
+	-rm -f emq-relx/_rel/emqttd/log/*
 	
 start_broker:
 	-emq-relx/_rel/emqttd/bin/emqttd stop
@@ -116,6 +117,8 @@ $(RELX_CONF):
 	@echo "start building ..."
 	make -C emq-relx -f Makefile
 	
+paho: $(PAHO_GIT)
+	@echo "clone paho"
 
 $(PAHO_GIT):
 	git clone https://github.com/eclipse/paho.mqtt-sn.embedded-c/
@@ -146,7 +149,7 @@ clean: clean_result
 	-rm -rf paho.mqtt-sn.embedded-c
 	
 	
-lazy: clean_result start_broker case6 stop_broker
+lazy: clean_result start_broker case1 stop_broker
 	@echo "lazy mode"
 	
 	

--- a/src/emq_sn_gateway.erl
+++ b/src/emq_sn_gateway.erl
@@ -585,10 +585,12 @@ transform(?PUBACK_PACKET(?PUBREL, MsgId), _FuncMsgIdToTopicId) ->
 transform(?PUBACK_PACKET(?PUBCOMP, MsgId), _FuncMsgIdToTopicId) ->
     ?SN_PUBREC_MSG(?SN_PUBCOMP, MsgId);
 
-transform(?SUBACK_PACKET(_MsgId, _QosTable), _FuncMsgIdToTopicId)->
-    % SUBACK is not sent in this way
-    % please refer to handle_info({suback, MsgId, [GrantedQos]}, ...)
-    error(false);
+transform(?SUBACK_PACKET(MsgId, _QosTable), _FuncMsgIdToTopicId)->
+    % if success, suback is sent by handle_info({suback, MsgId, [GrantedQos]}, ...)
+    % if failure, suback is sent in this function.
+    Flags = #mqtt_sn_flags{qos = 0},
+    ?SN_SUBACK_MSG(Flags, ?SN_INVALID_TOPIC_ID, MsgId, ?SN_RC_MQTT_FAILURE);
+
 
 transform(?UNSUBACK_PACKET(MsgId), _FuncMsgIdToTopicId)->
     ?SN_UNSUBACK_MSG(MsgId).


### PR DESCRIPTION
If subscribe is rejected by ACL rule, emqttd_protocol:receive() will call sent function to transform SUBACK immediately, which will lead to crash as emqtt/emqttd#1397 reported.