### PR TITLE
Clean registered topics if mqtt-sn client send a 2nd CONNECT in connected state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Load Plugin
 ### NOTE
 - Topic ID is per-client, and will be cleared if client disconnected with broker or keep-alive failure is detected in broker.
 - Please register your topics again each time connected with broker.
+- If your udp socket(mqtt-sn client) has successfully connected to broker, don't try to send another CONNECT on this socket again, which will lead to confusing behaviour. If you want to start from beging, please do as following:
+    + destroy your present socket and create a new socket to connect again
+    + or send DISCONNECT on the same socket and connect again.
 
 
 ### Library

--- a/intergration_test/Makefile
+++ b/intergration_test/Makefile
@@ -21,7 +21,7 @@ PAHO_SRC  = paho.mqtt-sn.embedded-c/MQTTSNPacket/src/MQTTSNConnectClient.c      
 INCLUDE_PATH = -Ipaho.mqtt-sn.embedded-c/MQTTSNPacket/src -Ipaho.mqtt-sn.embedded-c/MQTTSNPacket/samples -Iclient
 			
 
-all:  clean_result $(RELX_CONF) $(PAHO_GIT) start_broker case1 case2 case3 case4 case5 case6 case7 stop_broker disable_qos3
+all:  clean_result $(RELX_CONF) $(PAHO_GIT) start_broker case1 case2 case3 case4 case5 case6 case7 case8 stop_broker disable_qos3
 	@echo "  "
 	@echo "  test complete"
 	@echo "  "
@@ -99,6 +99,10 @@ case7:
 	gcc client/case7_double_connect.c $(PAHO_SRC) $(INCLUDE_PATH) -o client/case7_double_connect.exe
 	client/case7_double_connect.exe
 
+case8:
+	-ps aux|grep case8_2nd_connect_clean_topics|awk '{print $$2}'|xargs kill -9
+	gcc client/case8_2nd_connect_clean_topics.c $(PAHO_SRC) $(INCLUDE_PATH) -o client/case8_2nd_connect_clean_topics.exe
+	client/case8_2nd_connect_clean_topics.exe
 	
 	
 $(RELX_CONF):
@@ -154,7 +158,7 @@ clean: clean_result
 	-rm -rf paho.mqtt-sn.embedded-c
 	
 	
-lazy: clean_result start_broker case1 stop_broker
+lazy: clean_result start_broker case1 case2 case3 case4 case5 case6 case7 case8 stop_broker
 	@echo "lazy mode"
 	
 	

--- a/intergration_test/client/case6_sleep.c
+++ b/intergration_test/client/case6_sleep.c
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
     char *host = "127.0.0.1";
     int port = 1884;
     int i = 0;
-    MQTTSNString msstr;
+    MQTTSNString msstr = {0};
     MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
 
     mysock = transport_open();

--- a/intergration_test/client/case7_double_connect.c
+++ b/intergration_test/client/case7_double_connect.c
@@ -78,7 +78,7 @@ int main(int argc, char** argv)
     char *host = "127.0.0.1";
     int port = 1884;
     int i = 0;
-    MQTTSNString msstr;
+    MQTTSNString msstr = {0};
     MQTTSNPacket_connectData options = MQTTSNPacket_connectData_initializer;
 
     mysock = transport_open();
@@ -99,6 +99,7 @@ int main(int argc, char** argv)
 
     sleep(2);
 
+    // a new client-id on the same udp port will be refused by emq-sn
     options.clientID.cstring = "testclientid_case7_new";
     TLOG("will send connect with new clientId:%s\n", options.clientID.cstring);
     if((rc = connect(&options, host, port, buf, buflen)) == 0)
@@ -106,6 +107,7 @@ int main(int argc, char** argv)
 
     sleep(2);
 
+    // go back to the old client-id and the connection will be successful
     options.clientID.cstring = "testclientid_case7";
     TLOG("will send connect with old clientId:%s\n", options.clientID.cstring);
     if((rc = connect(&options, host, port, buf, buflen)) != 0)

--- a/test/emq_sn_protocol_SUITE.erl
+++ b/test/emq_sn_protocol_SUITE.erl
@@ -124,8 +124,8 @@ connect_test03(_Config) ->
     timer:sleep(300),
 
     send_connect_msg(Socket, <<"cleintid_other">>),
-    ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
-    ?assertEqual({<<"cleintid_other">>, <<"user1">>}, test_mqtt_broker:get_online_user()),
+    ?assertEqual(<<3, ?SN_CONNACK, 3>>, receive_response(Socket)),  % 3 is reject(not support)
+    ?assertEqual({<<"cleintid_test">>, <<"user1">>}, test_mqtt_broker:get_online_user()),
 
     gen_udp:close(Socket),
     test_mqtt_broker:stop().


### PR DESCRIPTION
Fix the bug of https://github.com/emqtt/emq-sn/issues/74.